### PR TITLE
fix: replace with `dagger core version`

### DIFF
--- a/scripts/warm-engine.sh
+++ b/scripts/warm-engine.sh
@@ -2,5 +2,5 @@
 
 # Make sure not to load any implicit module
 cd $(mktemp -d)
-# Run a simple query to "warm up" the engine
-echo '{directory{id}}' | dagger query
+# Run a simple core function to "warm up" the engine
+dagger core version


### PR DESCRIPTION
As mentioned in the community live stream today

Note: this would only work for dagger >= v0.12.5. Not sure if this is a concern or not?